### PR TITLE
Match edit refactoring rule

### DIFF
--- a/clang/include/clang/Basic/DiagnosticRefactoringKinds.td
+++ b/clang/include/clang/Basic/DiagnosticRefactoringKinds.td
@@ -30,6 +30,10 @@ def err_refactor_extract_prohibited_expression : Error<"the selected "
 
 def err_refactor_no_location : Error<"refactoring action can't be initiated "
   "without a location">;
+def err_refactor_no_location_match : Error<"refactoring action can't be initiated "
+  "without a matching location">;
+def err_refactor_invalid_edit_generator : Error<"refactoring action can't be initiated "
+  "without a correct edit generator">;
 }
 
 } // end of Refactoring diagnostics

--- a/clang/include/clang/Basic/DiagnosticRefactoringKinds.td
+++ b/clang/include/clang/Basic/DiagnosticRefactoringKinds.td
@@ -28,6 +28,8 @@ def err_refactor_extract_simple_expression : Error<"the selected expression "
 def err_refactor_extract_prohibited_expression : Error<"the selected "
   "expression cannot be extracted">;
 
+def err_refactor_no_location : Error<"refactoring action can't be initiated "
+  "without a location">;
 }
 
 } // end of Refactoring diagnostics

--- a/clang/include/clang/Tooling/Refactoring/Edit/EditMatchRule.h
+++ b/clang/include/clang/Tooling/Refactoring/Edit/EditMatchRule.h
@@ -1,0 +1,49 @@
+//===--- EditMatchRule.h - Clang refactoring library ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLING_REFACTORING_EDIT_EDITMATCHRULE_H
+#define LLVM_CLANG_TOOLING_REFACTORING_EDIT_EDITMATCHRULE_H
+
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Tooling/Refactoring/RefactoringActionRules.h"
+#include "clang/Tooling/Transformer/RewriteRule.h"
+
+namespace clang {
+namespace tooling {
+
+/// A "Edit Match" refactoring rule edits code around matches according to
+/// EditGenerator.
+class EditMatchRule final : public SourceChangeRefactoringRule {
+public:
+  /// Initiates the delete match refactoring operation.
+  ///
+  /// \param R    MatchResult  Match result to edit.
+  /// \param EG    EditGenerator  Edit to perform.
+  static Expected<EditMatchRule>
+  initiate(RefactoringRuleContext &Context,
+           ast_matchers::MatchFinder::MatchResult R,
+           transformer::EditGenerator EG);
+
+  static const RefactoringDescriptor &describe();
+
+private:
+  EditMatchRule(ast_matchers::MatchFinder::MatchResult R,
+                transformer::EditGenerator EG)
+      : Result(std::move(R)), EditGenerator(std::move(EG)) {}
+
+  Expected<AtomicChanges>
+  createSourceReplacements(RefactoringRuleContext &Context) override;
+
+  ast_matchers::MatchFinder::MatchResult Result;
+  transformer::EditGenerator EditGenerator;
+};
+
+} // end namespace tooling
+} // end namespace clang
+
+#endif // LLVM_CLANG_TOOLING_REFACTORING_EDIT_EDITMATCHRULE_H

--- a/clang/include/clang/Tooling/Refactoring/RefactoringActionRule.h
+++ b/clang/include/clang/Tooling/Refactoring/RefactoringActionRule.h
@@ -56,6 +56,10 @@ public:
   /// to be fulfilled before refactoring can be performed.
   virtual bool hasSelectionRequirement() = 0;
 
+  /// Returns true when the rule has a source location requirement that has
+  /// to be fulfilled before refactoring can be performed.
+  virtual bool hasLocationRequirement() = 0;
+
   /// Traverses each refactoring option used by the rule and invokes the
   /// \c visit callback in the consumer for each option.
   ///

--- a/clang/include/clang/Tooling/Refactoring/RefactoringActionRuleRequirements.h
+++ b/clang/include/clang/Tooling/Refactoring/RefactoringActionRuleRequirements.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLING_REFACTORING_REFACTORINGACTIONRULEREQUIREMENTS_H
 
 #include "clang/Basic/LLVM.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Tooling/Refactoring/ASTSelection.h"
 #include "clang/Tooling/Refactoring/RefactoringDiagnostic.h"
 #include "clang/Tooling/Refactoring/RefactoringOption.h"
@@ -75,6 +76,17 @@ class CodeRangeASTSelectionRequirement : public ASTSelectionRequirement {
 public:
   Expected<CodeRangeASTSelection>
   evaluate(RefactoringRuleContext &Context) const;
+};
+
+/// A base class for any requirement that expects source code position (or the
+/// refactoring tool with the -location option).
+class SourceLocationRequirement : public RefactoringActionRuleRequirement {
+public:
+  Expected<SourceLocation> evaluate(RefactoringRuleContext &Context) const {
+    if (Context.getLocation().isValid())
+      return Context.getLocation();
+    return Context.createDiagnosticError(diag::err_refactor_no_location);
+  }
 };
 
 /// A base class for any requirement that requires some refactoring options.

--- a/clang/include/clang/Tooling/Refactoring/RefactoringActionRulesInternal.h
+++ b/clang/include/clang/Tooling/Refactoring/RefactoringActionRulesInternal.h
@@ -139,6 +139,11 @@ createRefactoringActionRule(const RequirementTypes &... Requirements) {
                                  RequirementTypes...>::value;
     }
 
+    bool hasLocationRequirement() override {
+      return internal::HasBaseOf<SourceLocationRequirement,
+                                 RequirementTypes...>::value;
+    }
+
     void visitRefactoringOptions(RefactoringOptionVisitor &Visitor) override {
       internal::visitRefactoringOptions(
           Visitor, Requirements,

--- a/clang/include/clang/Tooling/Refactoring/RefactoringRuleContext.h
+++ b/clang/include/clang/Tooling/Refactoring/RefactoringRuleContext.h
@@ -30,6 +30,9 @@ namespace tooling {
 ///
 ///   - SelectionRange: an optional source selection ranges that can be used
 ///     to represent a selection in an editor.
+///
+///   - Location: an optional source location that can be used
+///     to represent a cursor in an editor.
 class RefactoringRuleContext {
 public:
   RefactoringRuleContext(const SourceManager &SM) : SM(SM) {}
@@ -40,7 +43,13 @@ public:
   /// refactoring engine. Can be invalid.
   SourceRange getSelectionRange() const { return SelectionRange; }
 
+  /// Returns the current source location as set by the
+  /// refactoring engine. Can be invalid.
+  SourceLocation getLocation() const { return Location; }
+
   void setSelectionRange(SourceRange R) { SelectionRange = R; }
+
+  void setLocation(SourceLocation L) { Location = L; }
 
   bool hasASTContext() const { return AST; }
 
@@ -73,6 +82,9 @@ private:
   /// An optional source selection range that's commonly used to represent
   /// a selection in an editor.
   SourceRange SelectionRange;
+  /// An optional source location that's commonly used to represent
+  /// a cursor in an editor.
+  SourceLocation Location;
   /// An optional AST for the translation unit on which a refactoring action
   /// might operate on.
   ASTContext *AST = nullptr;

--- a/clang/lib/Tooling/Refactoring/CMakeLists.txt
+++ b/clang/lib/Tooling/Refactoring/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(clangToolingRefactoring
   Rename/USRFinder.cpp
   Rename/USRFindingAction.cpp
   Rename/USRLocFinder.cpp
+  Edit/EditMatchRule.cpp
 
   LINK_LIBS
   clangAST
@@ -23,6 +24,7 @@ add_clang_library(clangToolingRefactoring
   clangLex
   clangRewrite
   clangToolingCore
+  clangTransformer
 
   DEPENDS
   omp_gen

--- a/clang/lib/Tooling/Refactoring/Edit/EditMatchRule.cpp
+++ b/clang/lib/Tooling/Refactoring/Edit/EditMatchRule.cpp
@@ -1,0 +1,74 @@
+//===--- EditMatchRule.cpp - Clang refactoring library --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implements the "edit-match" refactoring rule that can edit matcher results
+///
+//===----------------------------------------------------------------------===//
+
+#include "clang/Tooling/Refactoring/Edit/EditMatchRule.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Basic/DiagnosticRefactoring.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Tooling/Refactoring/AtomicChange.h"
+#include "clang/Tooling/Transformer/RewriteRule.h"
+#include "clang/Tooling/Transformer/SourceCode.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace transformer;
+
+Expected<EditMatchRule>
+EditMatchRule::initiate(RefactoringRuleContext &Context,
+                        ast_matchers::MatchFinder::MatchResult R,
+                        transformer::EditGenerator EG) {
+  return EditMatchRule(std::move(R), std::move(EG));
+}
+
+const RefactoringDescriptor &EditMatchRule::describe() {
+  static const RefactoringDescriptor Descriptor = {
+      "edit-match",
+      "Edit Match",
+      "Edits match result source code",
+  };
+  return Descriptor;
+}
+
+Expected<AtomicChanges>
+EditMatchRule::createSourceReplacements(RefactoringRuleContext &Context) {
+  ASTContext &AST = Context.getASTContext();
+  SourceManager &SM = AST.getSourceManager();
+  Expected<SmallVector<transformer::Edit, 1>> Edits = EditGenerator(Result);
+
+  if (!Edits) {
+    return std::move(Edits.takeError());
+  }
+  if (Edits->empty())
+    return Context.createDiagnosticError(
+        diag::err_refactor_invalid_edit_generator);
+
+  AtomicChange Change(SM, Edits->front().Range.getBegin());
+  {
+    for (const auto &Edit : *Edits) {
+      switch (Edit.Kind) {
+      case EditKind::Range:
+        if (auto Err = Change.replace(SM, std::move(Edit.Range),
+                                      std::move(Edit.Replacement))) {
+          return std::move(Err);
+        }
+        break;
+      case EditKind::AddInclude:
+        Change.addHeader(std::move(Edit.Replacement));
+        break;
+      }
+    }
+  }
+
+  return AtomicChanges{std::move(Change)};
+}


### PR DESCRIPTION
Modified capabilities of refactoring engine and clang-refactor tool:
- Added source location argument for clang-refactor tool
- Added corresponding source location requirement, that requests SourceLocation
- Added AST matcher(hasPointWithin), that checks that location is inside result node SourceRange 
- Added AST location match requirement, that requests ast_matcher::DeclarationMatcher or StatementMatcher, SourceLocation(it is source location requirement), wrappes given matcher with hasPointWithin matcher using requested location, matches AST and provides last match result
- Added AST edit requirement, that requests and provides transformer::ASTEdit
- Added Edit Match Refactoring rule, that edits given match result with given ASTEdit