### PR TITLE
Tests for refactoring actions and options 

### DIFF
--- a/clang/test/Refactor/Edit/RedundandIf.cpp
+++ b/clang/test/Refactor/Edit/RedundandIf.cpp
@@ -1,0 +1,64 @@
+// RUN: clang-refactor redundand-if -location=test:%s %s -- 2>&1 | grep -v CHECK | FileCheck %s
+
+void bodyLocation() {
+    if (false) {
+        int thenVar;
+        /*loc body_loc=*/
+    }
+}
+
+// CHECK: 1 'body_loc' results:
+// CHECK: void bodyLocation() {
+// CHECK-NEXT: {{^     }}
+// CHECK-NEXT: }
+
+void ifFalse() {
+    if (/*loc false=*/false) {
+        int thenVar;
+    } else {
+        int elseVar;
+    }
+}
+
+// CHECK: 1 'false' results:
+// CHECK: void ifFalse() {
+// CHECK-NEXT: {
+// CHECK-NEXT: int elseVar;
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+void ifFalseNoElse() {
+    if (/*loc false_no_else=*/false) {
+        int thenVar;
+    }
+}
+
+// CHECK: 1 'false_no_else' results:
+// CHECK: void ifFalseNoElse() {
+// CHECK-NEXT: {{^     }}
+// CHECK-NEXT: }
+
+void noMatchingLocation() {
+    /*loc no_matching_location=*/
+    if (false) {
+        int thenVar;
+    }
+}
+
+// CHECK: 1 'no_matching_location' results:
+// CHECK-NEXT: refactoring action can't be initiated without a matching location
+
+void ifTrue() {
+    if (/*loc true=*/true) {
+        int thenVar;
+    } else {
+        int elseVar;
+    }
+}
+
+// CHECK: 1 'true' results:
+// CHECK: void ifTrue() {
+// CHECK-NEXT: {
+// CHECK-NEXT: int thenVar;
+// CHECK-NEXT: }
+// CHECK-NEXT: }

--- a/clang/test/Refactor/Edit/RedundandWhile.cpp
+++ b/clang/test/Refactor/Edit/RedundandWhile.cpp
@@ -1,0 +1,35 @@
+// RUN: clang-refactor redundand-while -location=test:%s %s -- 2>&1 | grep -v CHECK | FileCheck %s
+
+void bodyLocation() {
+    while (false) {
+        int thenVar;
+        /*loc body_loc=*/
+    }
+}
+
+// CHECK: 1 'body_loc' results:
+// CHECK: void bodyLocation() {
+// CHECK-NEXT: {{^     }}
+// CHECK-NEXT: }
+
+void conditionLoc() {
+    while (/*loc false=*/false) {
+        int thenVar;
+    }
+}
+
+// CHECK: 1 'false' results:
+// CHECK: void conditionLoc() {
+// CHECK-NEXT: {{^     }}
+// CHECK-NEXT: }
+
+void noMatchingLocation() {
+    /*loc no_matching_location=*/
+    while (false) {
+        int thenVar;
+    }
+}
+
+// CHECK: 1 'no_matching_location' results:
+// CHECK-NEXT: refactoring action can't be initiated without a matching location
+

--- a/clang/test/Refactor/Edit/SimplifyExpr.cpp
+++ b/clang/test/Refactor/Edit/SimplifyExpr.cpp
@@ -1,0 +1,56 @@
+// RUN: clang-refactor simplify-expr -location=test:%s %s -- 2>&1 | grep -v CHECK | FileCheck %s
+
+bool foo = true;
+bool bar = false /*loc and_false_lhs=*/ && foo;
+
+// CHECK: 1 'and_false_lhs' results:
+// CHECK: bool bar = false;
+
+bool foo2 = true;
+bool bar2 = foo2 /*loc and_false_rhs=*/ && false;
+
+// CHECK: 1 'and_false_rhs' results:
+// CHECK: bool bar2 = false;
+
+bool foo3 = true;
+bool bar3 = true /*loc and_true_lhs=*/ && foo3;
+
+// CHECK: 1 'and_true_lhs' results:
+// CHECK: bool bar3 = foo3;
+
+bool foo4 = true;
+bool bar4 = foo4 /*loc and_true_rhs=*/ && true;
+
+// CHECK: 1 'and_true_rhs' results:
+// CHECK: bool bar4 = foo4;
+
+bool foo5 = true;
+bool bar5 = /*loc no_matching_location=*/ true || foo5;
+
+// CHECK: 1 'no_matching_location' results:
+// CHECK-NEXT: refactoring action can't be initiated without a matching location
+
+bool foo6 = true;
+bool bar6 = false /*loc or_false_lhs=*/ || foo6;
+
+// CHECK: 1 'or_false_lhs' results:
+// CHECK: bool bar6 = foo6;
+
+bool foo7 = true;
+bool bar7 = foo7 /*loc or_false_rhs=*/ || false;
+
+// CHECK: 1 'or_false_rhs' results:
+// CHECK: bool bar7 = foo7;
+
+bool foo8 = true;
+bool bar8 = true /*loc or_true_lhs=*/ || foo8;
+
+// CHECK: 1 'or_true_lhs' results:
+// CHECK: bool bar8 = true;
+//
+bool foo9 = true;
+bool bar9 = foo9 /*loc or_true_rhs=*/ || true;
+
+// CHECK: 1 'or_true_rhs' results:
+// CHECK: bool bar9 = true;
+

--- a/clang/test/Refactor/Edit/UnusedField.cpp
+++ b/clang/test/Refactor/Edit/UnusedField.cpp
@@ -1,0 +1,20 @@
+// RUN: clang-refactor unused-field -location=test:%s %s -- 2>&1 | grep -v CHECK | FileCheck %s
+
+struct Bar {
+    /*loc used=*/int member;
+    /*loc unused=*/int unusedMember;
+};
+
+void foo() {
+    Bar a;
+    a.member = 1;
+}
+
+// CHECK: 1 'unused' results:
+// CHECK: struct Bar {
+// CHECK-NEXT: /*loc used=*/int member;
+// CHECK-NEXT: /*loc unused=*/
+// CHECK-NEXT: };
+
+// CHECK: 1 'used' results:
+// CHECK-NEXT: refactoring action can't be initiated without a matching location

--- a/clang/test/Refactor/Edit/UnusedMethod.cpp
+++ b/clang/test/Refactor/Edit/UnusedMethod.cpp
@@ -1,0 +1,20 @@
+// RUN: clang-refactor unused-method -location=test:%s %s -- 2>&1 | grep -v CHECK | FileCheck %s
+
+struct Bar {
+    /*loc used=*/void used() {}
+    /*loc unused=*/void unused() {}
+};
+
+void foo() {
+    Bar a;
+    a.used();
+}
+
+// CHECK: 1 'unused' results:
+// CHECK: struct Bar {
+// CHECK-NEXT: /*loc used=*/void used() {}
+// CHECK-NEXT: /*loc unused=*/
+// CHECK-NEXT: };
+
+// CHECK: 1 'used' results:
+// CHECK-NEXT: refactoring action can't be initiated without a matching location

--- a/clang/test/Refactor/tool-location-option.cpp
+++ b/clang/test/Refactor/tool-location-option.cpp
@@ -1,0 +1,11 @@
+// RUN: rm -f %t.cp.cpp
+// RUN: cp %s %t.cp.cpp
+// RUN: clang-refactor simplify-expr -location=%t.cp.cpp:5:18 -v %t.cp.cpp -- | FileCheck --check-prefix=CHECK1 %s
+
+bool test = true && true;
+
+// CHECK1: invoking action 'simplify-expr':
+// CHECK1-NEXT: -location={{.*}}.cp.cpp:5:18
+
+// RUN: not clang-refactor simplify-expr -location=%s:5:18 -v %t.cp.cpp -- 2>&1 | FileCheck --check-prefix=CHECK-FILE-ERR %s
+// CHECK-FILE-ERR: given file is not in the target TU

--- a/clang/test/Refactor/tool-test-support-location.c
+++ b/clang/test/Refactor/tool-test-support-location.c
@@ -1,0 +1,40 @@
+// RUN: clang-refactor simplify-expr -location=test:%s -v %s -- | FileCheck %s
+
+/*loc =*/int test;
+
+/*loc named=*/int test2;
+
+/*loc = +1*/int test3;
+
+/* loc = +100 */int test4;
+
+/*loc named =+0*/int test5;
+
+// CHECK: Test location group '':
+// CHECK-NEXT:   89
+// CHECK-NEXT:   139
+// CHECK-NEXT:   176
+// CHECK-NEXT: Test location group 'named':
+// CHECK-NEXT:   114
+// CHECK-NEXT:   195
+
+// The following invocations are in the default group:
+
+// CHECK: invoking action 'simplify-expr':
+// CHECK-NEXT: -location={{.*}}tool-test-support-location.c:3:10
+
+// CHECK: invoking action 'simplify-expr':
+// CHECK-NEXT: -location={{.*}}tool-test-support-location.c:7:14
+
+// CHECK: invoking action 'simplify-expr':
+// CHECK-NEXT: -location={{.*}}tool-test-support-location.c:9:27
+
+// The following invocations are in the 'named' group, and they follow
+// the default invocation even if some of their locations occur prior to the
+// locations from the default group because the groups are tested one-by-one:
+
+// CHECK: invoking action 'simplify-expr':
+// CHECK-NEXT: -location={{.*}}tool-test-support-location.c:5:15
+
+// CHECK: invoking action 'simplify-expr':
+// CHECK-NEXT: -location={{.*}}tool-test-support-location.c:11:18

--- a/clang/test/Refactor/tool-test-support-range.c
+++ b/clang/test/Refactor/tool-test-support-range.c
@@ -24,23 +24,23 @@
 // The following invocations are in the default group:
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:3:11
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:3:11
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:7:15
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:7:15
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:9:29
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:9:29
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:13:19 -> {{.*}}tool-test-support.c:13:22
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:13:19 -> {{.*}}tool-test-support-range.c:13:22
 
 // The following invocations are in the 'named' group, and they follow
 // the default invocation even if some of their ranges occur prior to the
 // ranges from the default group because the groups are tested one-by-one:
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:5:17
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:5:17
 
 // CHECK: invoking action 'local-rename':
-// CHECK-NEXT: -selection={{.*}}tool-test-support.c:11:20
+// CHECK-NEXT: -selection={{.*}}tool-test-support-range.c:11:20

--- a/clang/tools/clang-refactor/ClangRefactor.cpp
+++ b/clang/tools/clang-refactor/ClangRefactor.cpp
@@ -200,6 +200,31 @@ public:
                   llvm::function_ref<void(SourceLocation L)> Callback) = 0;
 };
 
+/// Stores the parsed -location=test:<filename> option.
+class TestSourceLocationArgument final : public AbstractSourceLocationArgument {
+public:
+  TestSourceLocationArgument(TestLocationsInFile TestLocations)
+      : TestLocations(std::move(TestLocations)) {}
+
+  void print(raw_ostream &OS) override { TestLocations.dump(OS); }
+
+  std::unique_ptr<ClangRefactorToolConsumerInterface>
+  createCustomConsumer() override {
+    return TestLocations.createConsumer();
+  }
+
+  /// Testing support: invokes the location action for each source location in
+  /// the test file.
+  bool forAllLocations(
+      const SourceManager &SM,
+      llvm::function_ref<void(SourceLocation L)> Callback) override {
+    return TestLocations.foreachLocation(SM, Callback);
+  }
+
+private:
+  TestLocationsInFile TestLocations;
+};
+
 /// Stores the parsed -location=filename:line:column option.
 class SourceLocationArgument final : public AbstractSourceLocationArgument {
 public:
@@ -235,6 +260,15 @@ private:
 
 std::unique_ptr<AbstractSourceLocationArgument>
 AbstractSourceLocationArgument::fromString(StringRef Value) {
+  if (Value.starts_with("test:")) {
+    StringRef Filename = Value.drop_front(strlen("test:"));
+    std::optional<TestLocationsInFile> ParsedTestLocations =
+        findTestLocations(Filename);
+    if (!ParsedTestLocations)
+      return nullptr; // A parsing error was already reported.
+    return std::make_unique<TestSourceLocationArgument>(
+        std::move(*ParsedTestLocations));
+  }
   ParsedSourceLocation Location = ParsedSourceLocation::FromString(Value);
   if (Location.FileName != "")
     return std::make_unique<SourceLocationArgument>(std::move(Location));
@@ -509,8 +543,11 @@ public:
     std::unique_ptr<ClangRefactorToolConsumerInterface> TestConsumer;
     bool HasSelection = MatchingRule->hasSelectionRequirement();
     bool HasLocation = MatchingRule->hasLocationRequirement();
-    if (HasSelection)
+    if (HasSelection) {
       TestConsumer = SelectedSubcommand->getSelection()->createCustomConsumer();
+    } else if (HasLocation) {
+      TestConsumer = SelectedSubcommand->getLocation()->createCustomConsumer();
+    }
     ClangRefactorToolConsumerInterface *ActiveConsumer =
         TestConsumer ? TestConsumer.get() : Consumer.get();
     ActiveConsumer->beginTU(AST);

--- a/clang/tools/clang-refactor/TestSupport.cpp
+++ b/clang/tools/clang-refactor/TestSupport.cpp
@@ -15,6 +15,7 @@
 #include "TestSupport.h"
 #include "clang/Basic/DiagnosticError.h"
 #include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
 #include "llvm/ADT/STLExtras.h"
@@ -65,6 +66,38 @@ bool TestSelectionRangesInFile::foreachRange(
   return false;
 }
 
+void TestLocationsInFile::dump(raw_ostream &OS) const {
+  for (const auto &Group : GroupedLocations) {
+    OS << "Test location group '" << Group.Name << "':\n";
+    for (const auto &Location : Group.Locations) {
+      OS << "  " << Location << "\n";
+    }
+  }
+}
+
+bool TestLocationsInFile::foreachLocation(
+    const SourceManager &SM,
+    llvm::function_ref<void(SourceLocation)> Callback) const {
+  auto FE = SM.getFileManager().getFile(Filename);
+  FileID FID = FE ? SM.translateFile(*FE) : FileID();
+  if (!FE || FID.isInvalid()) {
+    llvm::errs() << "error: -location=test:" << Filename
+                 << " : given file is not in the target TU";
+    return true;
+  }
+  SourceLocation FileLoc = SM.getLocForStartOfFile(FID);
+  for (const auto &Group : GroupedLocations) {
+    for (const auto &Location : Group.Locations) {
+      // Translate the offset to a true source location.
+      SourceLocation Loc =
+          SM.getMacroArgExpandedLocation(FileLoc.getLocWithOffset(Location));
+      assert(Loc.isValid() && "unexpected invalid range");
+      Callback(Loc);
+    }
+  }
+  return false;
+}
+
 namespace {
 
 void dumpChanges(const tooling::AtomicChanges &Changes, raw_ostream &OS) {
@@ -108,15 +141,12 @@ bool printRewrittenSources(const tooling::AtomicChanges &Changes,
   return false;
 }
 
-class TestRefactoringResultConsumer final
+class GroupedTestRefactoringResultConsumer
     : public ClangRefactorToolConsumerInterface {
 public:
-  TestRefactoringResultConsumer(const TestSelectionRangesInFile &TestRanges)
-      : TestRanges(TestRanges) {
-    Results.push_back({});
-  }
+  GroupedTestRefactoringResultConsumer() { Results.push_back({}); }
 
-  ~TestRefactoringResultConsumer() {
+  ~GroupedTestRefactoringResultConsumer() {
     // Ensure all results are checked.
     for (auto &Group : Results) {
       for (auto &Result : Group) {
@@ -138,15 +168,22 @@ public:
   }
 
 private:
+  virtual size_t getGroupSize(size_t Idx) = 0;
+
+  virtual std::string getGroupName(size_t Idx) = 0;
+
+  virtual size_t getGroupsAmount() = 0;
+
+  virtual void reportResultMismatch(size_t GroupIdx, size_t ResIdx) = 0;
+
   bool handleAllResults();
 
   void handleResult(Expected<tooling::AtomicChanges> Result) {
     Results.back().push_back(std::move(Result));
     size_t GroupIndex = Results.size() - 1;
-    if (Results.back().size() >=
-        TestRanges.GroupedRanges[GroupIndex].Ranges.size()) {
+    if (Results.back().size() >= getGroupSize(GroupIndex)) {
       ++GroupIndex;
-      if (GroupIndex >= TestRanges.GroupedRanges.size()) {
+      if (GroupIndex >= getGroupsAmount()) {
         if (handleAllResults())
           exit(1); // error has occurred.
         return;
@@ -155,7 +192,6 @@ private:
     }
   }
 
-  const TestSelectionRangesInFile &TestRanges;
   std::vector<std::vector<Expected<tooling::AtomicChanges>>> Results;
 };
 
@@ -172,9 +208,71 @@ std::pair<unsigned, unsigned> getLineColumn(StringRef Filename,
           (LastLine == StringRef::npos ? Offset : Offset - LastLine) + 1};
 }
 
+class TestSelectionRangesResultConsumer final
+    : public GroupedTestRefactoringResultConsumer {
+public:
+  TestSelectionRangesResultConsumer(const TestSelectionRangesInFile &TestRanges)
+      : TestRanges(TestRanges) {}
+
+private:
+  size_t getGroupSize(size_t Idx) override {
+    return TestRanges.GroupedRanges[Idx].Ranges.size();
+  }
+
+  std::string getGroupName(size_t Idx) override {
+    return TestRanges.GroupedRanges[Idx].Name;
+  }
+
+  size_t getGroupsAmount() override { return TestRanges.GroupedRanges.size(); }
+
+  void reportResultMismatch(size_t GroupIdx, size_t ResIdx) override {
+    std::pair<unsigned, unsigned> LineColumn =
+        getLineColumn(TestRanges.Filename,
+                      TestRanges.GroupedRanges[GroupIdx].Ranges[ResIdx].Begin);
+    llvm::errs()
+        << "error: unexpected refactoring result for range starting at "
+        << LineColumn.first << ':' << LineColumn.second << " in group '"
+        << TestRanges.GroupedRanges[GroupIdx].Name << "':\n  ";
+  }
+
+  const TestSelectionRangesInFile &TestRanges;
+};
+
+class TestLocationsResultConsumer final
+    : public GroupedTestRefactoringResultConsumer {
+public:
+  TestLocationsResultConsumer(const TestLocationsInFile &TestLocations)
+      : TestLocations(TestLocations) {}
+
+private:
+  size_t getGroupSize(size_t Idx) override {
+    return TestLocations.GroupedLocations[Idx].Locations.size();
+  }
+
+  std::string getGroupName(size_t Idx) override {
+    return TestLocations.GroupedLocations[Idx].Name;
+  }
+
+  size_t getGroupsAmount() override {
+    return TestLocations.GroupedLocations.size();
+  }
+
+  void reportResultMismatch(size_t GroupIdx, size_t ResIdx) override {
+    std::pair<unsigned, unsigned> LineColumn = getLineColumn(
+        TestLocations.Filename,
+        TestLocations.GroupedLocations[GroupIdx].Locations[ResIdx]);
+    llvm::errs() << "error: unexpected refactoring result for location at "
+                 << LineColumn.first << ':' << LineColumn.second
+                 << " in group '"
+                 << TestLocations.GroupedLocations[GroupIdx].Name << "':\n  ";
+  }
+
+  const TestLocationsInFile &TestLocations;
+};
+
 } // end anonymous namespace
 
-bool TestRefactoringResultConsumer::handleAllResults() {
+bool GroupedTestRefactoringResultConsumer::handleAllResults() {
   bool Failed = false;
   for (const auto &Group : llvm::enumerate(Results)) {
     // All ranges in the group must produce the same result.
@@ -216,13 +314,7 @@ bool TestRefactoringResultConsumer::handleAllResults() {
       }
       Failed = true;
       // Report the mismatch.
-      std::pair<unsigned, unsigned> LineColumn = getLineColumn(
-          TestRanges.Filename,
-          TestRanges.GroupedRanges[Group.index()].Ranges[I.index()].Begin);
-      llvm::errs()
-          << "error: unexpected refactoring result for range starting at "
-          << LineColumn.first << ':' << LineColumn.second << " in group '"
-          << TestRanges.GroupedRanges[Group.index()].Name << "':\n  ";
+      reportResultMismatch(Group.index(), I.index());
       if (HasResult)
         llvm::errs() << "valid result";
       else
@@ -241,14 +333,13 @@ bool TestRefactoringResultConsumer::handleAllResults() {
     }
 
     // Dump the results:
-    const auto &TestGroup = TestRanges.GroupedRanges[Group.index()];
     if (!CanonicalResult) {
-      llvm::outs() << TestGroup.Ranges.size() << " '" << TestGroup.Name
-                   << "' results:\n";
+      llvm::outs() << getGroupSize(Group.index()) << " '"
+                   << getGroupName(Group.index()) << "' results:\n";
       llvm::outs() << *CanonicalErrorMessage << "\n";
     } else {
-      llvm::outs() << TestGroup.Ranges.size() << " '" << TestGroup.Name
-                   << "' results:\n";
+      llvm::outs() << getGroupSize(Group.index()) << " '"
+                   << getGroupName(Group.index()) << "' results:\n";
       if (printRewrittenSources(*CanonicalResult, llvm::outs()))
         return true;
     }
@@ -258,7 +349,12 @@ bool TestRefactoringResultConsumer::handleAllResults() {
 
 std::unique_ptr<ClangRefactorToolConsumerInterface>
 TestSelectionRangesInFile::createConsumer() const {
-  return std::make_unique<TestRefactoringResultConsumer>(*this);
+  return std::make_unique<TestSelectionRangesResultConsumer>(*this);
+}
+
+std::unique_ptr<ClangRefactorToolConsumerInterface>
+TestLocationsInFile::createConsumer() const {
+  return std::make_unique<TestLocationsResultConsumer>(*this);
 }
 
 /// Adds the \p ColumnOffset to file offset \p Offset, without going past a
@@ -388,6 +484,84 @@ findTestSelectionRanges(StringRef Filename) {
   for (auto &Group : GroupedRanges)
     TestRanges.GroupedRanges.push_back({Group.first, std::move(Group.second)});
   return std::move(TestRanges);
+}
+
+std::optional<TestLocationsInFile> findTestLocations(StringRef Filename) {
+  ErrorOr<std::unique_ptr<MemoryBuffer>> ErrOrFile =
+      MemoryBuffer::getFile(Filename);
+  if (!ErrOrFile) {
+    llvm::errs() << "error: -location=test:" << Filename
+                 << " : could not open the given file";
+    return std::nullopt;
+  }
+  StringRef Source = ErrOrFile.get()->getBuffer();
+
+  // See the doc comment for this function for the explanation of this
+  // syntax.
+  static const Regex LocationRegex(
+      "loc[[:blank:]]+([[:alpha:]_]*)?[[:blank:]]*=[[:"
+      "blank:]]*(\\+[[:digit:]]+)?");
+
+  std::map<std::string, SmallVector<unsigned, 8>> GroupedLocations;
+
+  LangOptions LangOpts;
+  LangOpts.CPlusPlus = 1;
+  LangOpts.CPlusPlus11 = 1;
+  Lexer Lex(SourceLocation::getFromRawEncoding(0), LangOpts, Source.begin(),
+            Source.begin(), Source.end());
+  Lex.SetCommentRetentionState(true);
+  Token Tok;
+  for (Lex.LexFromRawLexer(Tok); Tok.isNot(tok::eof);
+       Lex.LexFromRawLexer(Tok)) {
+    if (Tok.isNot(tok::comment))
+      continue;
+    StringRef Comment =
+        Source.substr(Tok.getLocation().getRawEncoding(), Tok.getLength());
+    SmallVector<StringRef, 3> Matches;
+    // Try to detect mistyped 'location:' comments to ensure tests don't miss
+    // anything.
+    auto DetectMistypedCommand = [&]() -> bool {
+      if (Comment.contains_insensitive("loc") && Comment.contains("=") &&
+          !Comment.contains_insensitive("run") && !Comment.contains("CHECK")) {
+        llvm::errs() << "error: suspicious comment '" << Comment
+                     << "' that "
+                        "resembles the location command found\n";
+        llvm::errs()
+            << "note: please reword if this isn't a location command\n";
+      }
+      return false;
+    };
+    // Allow CHECK: comments to contain location= commands.
+    if (!LocationRegex.match(Comment, &Matches) || Comment.contains("CHECK")) {
+      if (DetectMistypedCommand())
+        return std::nullopt;
+      continue;
+    }
+    unsigned Offset = Tok.getEndLoc().getRawEncoding();
+    unsigned ColumnOffset = 0;
+    if (!Matches[2].empty()) {
+      // Don't forget to drop the '+'!
+      if (Matches[2].drop_front().getAsInteger(10, ColumnOffset))
+        assert(false && "regex should have produced a number");
+    }
+    Offset = addColumnOffset(Source, Offset, ColumnOffset);
+
+    auto It = GroupedLocations.insert(
+        std::make_pair(Matches[1].str(), SmallVector<unsigned, 8>{Offset}));
+    if (!It.second)
+      It.first->second.push_back(Offset);
+  }
+  if (GroupedLocations.empty()) {
+    llvm::errs() << "error: -location=test:" << Filename
+                 << ": no 'location' commands";
+    return std::nullopt;
+  }
+
+  TestLocationsInFile TestLocations = {Filename.str(), {}};
+  for (auto &Group : GroupedLocations)
+    TestLocations.GroupedLocations.push_back(
+        {Group.first, std::move(Group.second)});
+  return std::move(TestLocations);
 }
 
 } // end namespace refactor

--- a/clang/tools/clang-refactor/TestSupport.h
+++ b/clang/tools/clang-refactor/TestSupport.h
@@ -98,6 +98,61 @@ struct TestSelectionRangesInFile {
 std::optional<TestSelectionRangesInFile>
 findTestSelectionRanges(StringRef Filename);
 
+/// A set of test source locations specified in one file.
+///
+/// Test source location specified in a test file using an inline
+/// command in the comment. These commands can take the following forms:
+///
+/// - /*loc =*/ will create a source location in the default group
+///   right after the comment.
+/// - /*loc a=*/ will create a source location in the 'a' group right
+///   after the comment.
+/// - /*loc = +1*/ will create a source location at a location that's
+///   right after the comment with one offset to the column.
+///
+/// Clang-refactor will expect all locations in one test group to produce
+/// identical results.
+struct TestLocationsInFile {
+  std::string Filename;
+  struct LocationGroup {
+    std::string Name;
+    SmallVector<unsigned, 8> Locations;
+  };
+  std::vector<LocationGroup> GroupedLocations;
+
+  bool foreachLocation(const SourceManager &SM,
+                       llvm::function_ref<void(SourceLocation)> Callback) const;
+
+  std::unique_ptr<ClangRefactorToolConsumerInterface> createConsumer() const;
+
+  void dump(llvm::raw_ostream &OS) const;
+};
+
+/// Extracts the grouped source locations from the file that's specified in
+/// the -location=test:<filename> option.
+///
+/// The grouped locations are specified in comments using the following syntax:
+/// "loc" " " [ group-name ] "=" [ "+" column-offset ]
+///
+/// The source location is then computed from this command by taking the ending
+/// location of the comment, and adding 'column-offset' to the column
+/// for that location.
+///
+/// All source locations in one group are expected to produce the same
+/// refactoring result.
+///
+/// When testing, zero is returned from clang-refactor even when a group
+/// produces an initiation error, which is different from normal invocation
+/// that returns a non-zero value. This is done on purpose, to ensure that group
+/// consistency checks can return non-zero, but still print the output of
+/// the group. So even if a test matches the output of group, it will still fail
+/// because clang-refactor should return zero on exit when the group results are
+/// consistent.
+///
+/// \returns std::nullopt on failure (errors are emitted to stderr), or a set of
+/// grouped source locations in the given file otherwise.
+std::optional<TestLocationsInFile> findTestLocations(StringRef Filename);
+
 } // end namespace refactor
 } // end namespace clang
 


### PR DESCRIPTION
Modified abilities of refactoring engine and clang-refactor tool:
- Added test support for location argument
- Added tests for modified test support
- Added tests for location argument
- Added tests for new refactoring actions(redundand-if, redundand-while, simplify-expr, unused-field, unused-method)